### PR TITLE
Revert `git new` and `git done` from aliases to scripts for simplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of small scripts to make the git workflow easier
 
 These scripts are intended for making the GitHub workflow easier.
 They support a single "central" repo as well as the common dual
-"upstream/fork" repo setups.  In particular, both the setup recommended
+"upstream/fork" repo setups. In particular, both the setup recommended
 by GitHub's [help on configuring remotes][] (upstream named `upstream`
 and fork named `origin`) and the setup created by the GitHub's
 [hub tool]() (upstream named `origin` and fork named `$GIHUB_USER`) are
@@ -12,7 +12,6 @@ supported.
 
 Note that nothing prevents using most of these scripts with other
 hosting services like GitLab.
-
 
 ## Installation
 
@@ -24,9 +23,7 @@ cd git-scripts
 ./install.sh
 ```
 
-This will place the scripts in `$HOME/bin` and add a couple aliases to
-your `git config` if they don't already exist.
-
+This will place the scripts in `$HOME/bin`.
 
 ## Basic Usage
 
@@ -90,6 +87,7 @@ git hub-user
 ```
 
 Finds the value from the following sources in descending order:
+
 1. environment (`$GITHUB_USER`)
 2. .git/config or ~/.gitconfig (`git config --get hub.user`)
 3. ~/.config/hub (`github.com -> [0] -> user`)
@@ -113,6 +111,7 @@ git new <branch>
 Creates a new branch from master.
 
 Arguments:
+
 - `branch`: the name of the new branch to create
 
 ### `git prepare`
@@ -124,6 +123,7 @@ git prepare [upstream] [branch]
 Prepare your current branch for a pull request.
 
 Arguments:
+
 - `upstream`: defaults to `git hub-remotes --upstream`
 - `branch`: defaults to "master"
 
@@ -144,12 +144,13 @@ git sync [upstream] [fork] [branch]
 Keep your local and fork repos synced with upstream.
 
 Arguments:
+
 - `upstream`: defaults to `git hub-remotes --upstream`
 - `fork`: defaults to `git hub-remotes --fork`
 - `branch`: defaults to the current branch
 
 Pulls the latest commits from `[upstream]/[branch]` and then pushes
-to `[fork]/[branch]`.  Uses `pull --prune` and `push --prune` to remove
+to `[fork]/[branch]`. Uses `pull --prune` and `push --prune` to remove
 old branch references.
 
 ### `git tidy`

--- a/git-done
+++ b/git-done
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Finish a branch: `git checkout master`, `git sync`, and `git tidy`.
+
+set -e  # stop on error
+
+
+git checkout master
+
+git sync
+
+git tidy

--- a/git-new
+++ b/git-new
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Start a new branch: `git checkout master` and `git checkout -b <name>`.
+#
+# $1 = branch
+
+set -e  # stop on error
+
+
+git checkout master
+
+git checkout -b "$1"

--- a/install.sh
+++ b/install.sh
@@ -5,11 +5,6 @@ set -e  # Stop on error.
 # Run from the the script directory.
 cd "$(dirname "$0")"
 
-# Install scripts.
 mkdir -p "$HOME/bin"
-rsync -avh --no-perms "$PWD"/git-* "$HOME/bin/"
 
-# Insall aliases.
-if ! git config --global --get alias.new >/dev/null; then
-  git config --global alias.new "!git checkout master && git checkout -b"
-fi
+rsync -avh --no-perms "$PWD"/git-* "$HOME/bin/"

--- a/install.sh
+++ b/install.sh
@@ -5,16 +5,11 @@ set -e  # Stop on error.
 # Run from the the script directory.
 cd "$(dirname "$0")"
 
-echo "Installing scripts..."
+# Install scripts.
 mkdir -p "$HOME/bin"
 rsync -avh --no-perms "$PWD"/git-* "$HOME/bin/"
-echo "Done."
 
-echo "Installing aliases..."
+# Insall aliases.
 if ! git config --global --get alias.new >/dev/null; then
   git config --global alias.new "!git checkout master && git checkout -b"
 fi
-if ! git config --global --get alias.done >/dev/null; then
-  git config --global alias.done "!git checkout master && git sync && git tidy"
-fi
-echo "Done."


### PR DESCRIPTION
- **Revert "Convert git-done to an alias"**
- **Revert "Convert git-new to an alias"**
- **Clean up README**
